### PR TITLE
Make gas estimation for UserOps more reliable across bundlers

### DIFF
--- a/src/smart-wallet.ts
+++ b/src/smart-wallet.ts
@@ -43,6 +43,10 @@ export async function buildUserOp(
     args: [account, 0n],
   });
   let maxFeesPerGas = await estimateFeesPerGas(client);
+  // Increase the maxFeePerGas by 20% to account for differences between viem's
+  // internal gas estimation and Pimlico's custom gas estimation. Pimlico
+  // rejects UserOps with gas fees that are too low.
+  maxFeesPerGas.maxFeePerGas = BigInt(Math.floor(Number(maxFeesPerGas.maxFeePerGas) * 1.2));
 
   const dummySigFunc = signatureType === "secp256k1" ? buildDummySecp256k1 : buildDummyWebAuthn;
   const signature = dummySigFunc();


### PR DESCRIPTION
It looks like viem's gas estimation using fee data from Alchemy returns slightly lower values than custom Pimlico's gas estimation RPC. Pimlico rejects userOps that are priced below their threshold. For example:

```
Details: maxFeePerGas must be at least 21464490 (current maxFeePerGas: 18952684) - use pimlico_getUserOperationGasPrice to get the current gas price
```

This change just adds a 20% buffer to the maxFeePerGas estimate to account for the typical difference we've seen between the estimates.