### PR TITLE
Correction of Grammatical Errors

### DIFF
--- a/docs/pages/architecture.mdx
+++ b/docs/pages/architecture.mdx
@@ -4,13 +4,13 @@ title: Architecture
 
 # Architecture
 
-Keyspace is a minimal zero-knowledge rollup that settles on Ethereum. It's minimal in that it doesn't implement a zkEVM like most rollups. Instead, there are a few specific state changes defined by the rollup.
+Keyspace is a minimal zero-knowledge rollup that settles on Ethereum. It's minimal in that it does not implement a zkEVM like most rollups. Instead, there are a few specific state changes defined by the rollup.
 
 Keyspace's internal state is an [Indexed Merkle Tree](https://docs.aztec.network/aztec/concepts/storage/trees/indexed_merkle_tree), which allows brand new wallets to easily prove that they've never changed their keys so they aren't in the tree, and recovered wallets to prove the current configuration of their wallet. The root of this Merkle tree is managed by the `KeyStore` contract on L1, where state transitions are verified by SNARK proofs.
 
 ## Rollup Node
 
-The Keyspace node is derived from go-ethereum to monitor the L1 chain for activity in the KeyStore contract and respond to JSON RPC calls from [clients](/clients) requesting key changes. There currently is no gossip protocol between nodes, so the activity in the KeyStore contract is the only method for Keyspace nodes to communicate.
+The Keyspace node is derived from Go-Ethereum to monitor the L1 chain for activity in the KeyStore contract and respond to JSON-RPC calls from [clients](/clients) requesting key changes. There currently is no gossip protocol between nodes, so the activity in the KeyStore contract is the only method for Keyspace nodes to communicate.
 
 ## L1 KeyStore Contract
 
@@ -22,13 +22,13 @@ The sequencer generates a recursive batch proof that contains proofs of each cli
 
 ## L2 KeyStore Contract
 
-Cross-chain wallets and other applications integrate with Keyspace by reading from a local L2 KeyStore contract with the latest state from L1. The state is trustlessly synced from L1 using Merkle proofs of the L1 KeyStore contract's storage. (The state can also be trustlessly synced via deposit transactions from L1, but that currently costs more gas.) Currently, this syncing is performed by the Keyspace sequencer, but it can extracted and run independently of the sequencer.
+Cross-chain wallets and other applications integrate with Keyspace by reading from a local L2 KeyStore contract with the latest state from L1. The state is trustlessly synced from L1 using Merkle proofs of the L1 KeyStore contract's storage. (The state can also be trustlessly synced via deposit transactions from L1, but that currently costs more gas.) Currently, this syncing is performed by the Keyspace sequencer, but it can be extracted and run independently of the sequencer.
 
 :::note
-ERC 4337 wallets are not allowed to read storage outside their own contracts, which means that can't read from the L2 KeyStore contract without violating the requirements of the standard. Our current examples read from this storage anyway and rely on a non-compliant bundler to process their transactions. Upcoming work will implement an ERC 4337 aggregator to handle this storage read on behalf of all wallets.
+ERC 4337 wallets are not allowed to read storage outside their own contracts, which means that they can not read from the L2 KeyStore contract without violating the requirements of the standard. Our current examples read from this storage anyway and rely on a non-compliant bundler to process their transactions. Upcoming work will implement an ERC 4337 aggregator to handle this storage read on behalf of all wallets.
 :::
 
-## `Account` Circuits
+## Account Circuits
 
 Key changes are authenticated by [`Account` circuits](/authentication) that generate proofs that the key change is authorized. Integrators will typically use common circuits like an M-of-N multisignature circuit, but you're free to implement your own custom logic to handle key changes.
 
@@ -38,4 +38,4 @@ Key changes are authenticated by [`Account` circuits](/authentication) that gene
 
 ## Support Services
 
-To provide a better user experience, vendors can operate their own [support services](/web-services) that monitor changes to Keyspace's state and indexes the latest state of all of their wallets.
+To provide a better user experience, vendors can operate their own [support services](/web-services) that monitor changes to Keyspace's state and index the latest state of all of their wallets.

--- a/docs/pages/original-spec.mdx
+++ b/docs/pages/original-spec.mdx
@@ -54,7 +54,7 @@ The user's `key` is defined as:
 key = poseidon_bn254(keccak256(original_vk) >> 8, keccak256(original_data) >> 8)
 ```
 
-This `key` is the key used for IMT exclusion / inclusion proofs.
+This `key` is the key used for IMT exclusion/inclusion proofs.
 
 :::info
 The `keccak256` hashes are right-shifted by `8` bits to ensure they fit within field elements (theoretically could shift by `3`, but `8` makes the in-circuit keccak slightly simpler by sticking to byte boundaries). This is also done below for other instances of `keccak256` hashes.
@@ -66,12 +66,12 @@ In order to generate constant-size verification keys and proofs for different ci
 
 ### Usage of `key` from wallets
 
-Users create a SCW that hardcodes their `key` as an immutable value. In order to validate the current state of `key`, the SCW signature validation logic could do the following (in the simple ECDSA case mentioned above):
+Users create a SCW that hardcodes their `key` as an immutable value. In order to validate the current state of the `key`, the SCW signature validation logic could do the following (in the simple ECDSA case mentioned above):
  - Require a `signature`, `publicKey`, and `stateProof` as inputs
  - Verify that the `signature` signs the expected data (e.g. the `userOpHash`) with a private key for `publicKey`
- - Verify that the `publicKey` passed is the current `value` in the IMT for the `key` hardcoded in the SCW, using a BN254 PLONK proof to verify IMT exclusion / inclusion (see [`State` circuit](#State-circuit)).
+ - Verify that the `publicKey` passed is the current `value` in the IMT for the `key` hardcoded in the SCW, using a BN254 PLONK proof to verify IMT exclusion/inclusion (see [`State` circuit](#State-circuit)).
 
-In order to make wallets immediately useable without waiting for keystore propagation, users can provide exclusion proofs, proving that nothing exists in the IMT for their `key`. If they have performed a recovery in the past, they will have to provide an inclusion proof, proving that the current `value` in the key matches the `publicKey` they passed (encoded in the `data` variable that is hashed to the `newKey` value stored in the IMT).
+In order to make wallets immediately usable without waiting for keystore propagation, users can provide exclusion proofs, proving that nothing exists in the IMT for their `key`. If they have performed a recovery in the past, they will have to provide an inclusion proof, proving that the current `value` in the key matches the `publicKey` they passed (encoded in the `data` variable that is hashed to the `newKey` value stored in the IMT).
 
 ### Recovery via rollup
 
@@ -98,7 +98,7 @@ txHash = uint256(keccak256(abi.encodePacked(
 ))) >> 8;
 ```
 
-This acts as an forced-inclusion / anti-censorship mechanism. When proving blocks, the `KeyStore` contract uses `txHash` as a public input to the proof verification. The prover must perform the same hashes in-circuit, therefore proving that each transaction was included in the same order. This makes the rollup a [based rollup](https://ethresear.ch/t/based-rollups-superpowers-from-l1-sequencing/15016).
+This acts as a forced-inclusion / anti-censorship mechanism. When proving blocks, the `KeyStore` contract uses `txHash` as a public input for proof verification. The prover must perform the same hashes in-circuit, thereby proving that each transaction was included in the same order. This makes the rollup a [based rollup](https://ethresear.ch/t/based-rollups-superpowers-from-l1-sequencing/15016).
 
 ### Contracts
 
@@ -172,7 +172,7 @@ We use BN254 for any proof verifications performed on the EVM, as Ethereum suppo
 
 We use BW6-761 as it forms a 2-chain with BLS12-377, making verification of BLS12-377 proofs efficient in BW6-761.
 
-A simpler design we explored early on used no recursion, and relied on users to submit BN254 proofs for recovery directly to the L1. However we deemed this a non-starter due to the high fees of recovery (2kb of calldata and 350k gas to verify a PLONK proof).
+A simpler design we explored early on used no recursion, and relied on users to submit BN254 proofs for recovery directly to the L1. However we deemed this a non-starter due to the high fees of recovery (2KB of calldata and 350k gas to verify a PLONK proof).
 :::
 
 There are 5 circuits involved in this design; 2 for each user's account ([`State`](#State-circuit), [`Account`](#Account-circuit)), and 3 specifically for the keystore ([`Hash`](#Hash-circuit), [`Batch`](#Batch-circuit), [`Update`](#Update-circuit)).
@@ -444,10 +444,10 @@ There must be some incentive for a prover to provide proofs for the rollup to be
 ### Trusted setup
 
 There are three trusted setups required for this proposal:
- - `BN254` KZG for the `Update` circuit (approx. 45m constraints)
+ - `BN254` KZG for the `Update` circuit (approximately 45m constraints)
      - We can likely reuse the Hermez trusted setup here
- - `BW6-671` KZG for the `Batch` circuit (approx. ? constraints)
- - `BLS12-377` KZG for the `Hash` + `Account` circuits (approx. 20m constraints)
+ - `BW6-671` KZG for the `Batch` circuit (approximately ? constraints)
+ - `BLS12-377` KZG for the `Hash` + `Account` circuits (approximately 20m constraints)
 
 We'll need Powers of Tau ceremonies for these, or rely on others (see some linked [here](https://github.com/Consensys/gnark/discussions/1014)).
 
@@ -472,9 +472,9 @@ Thus Alice can generate a counterfactual address for a SCW controlled by Bob's k
 ## Future improvements
 
 #### 4337 + PLONK proof enshrinement
-Currently there's still a pretty large gas cost for each SCW transaction for wallets that use the keystore. Verifying a PLONK proof is mostly compute gas which is generally cheap on L2s with blocks below their target gas (and therefore the base fee is low). However the proof size is ~1kb and calldata is the bulk of the cost of transactions on L2s. 4844 will help here, and we can do some aggregation of these proofs for multiple keystore txs in a bundle.
+Currently there's still a pretty large gas cost for each SCW transaction for wallets that use the keystore. Verifying a PLONK proof is mostly compute gas which is generally cheap on L2s with blocks below their target gas (and therefore the base fee is low). However the proof size is ~1KB and calldata is the bulk of the cost of transactions on L2s. 4844 will help here, and we can do some aggregation of these proofs for multiple keystore txs in a bundle.
 
 Any protocol improvements that reduce the cost of 4337 and/or PLONK verification would reduce fees further.
 
 #### Blob DA
-Right now all keystore rollup transactions are submitted as calldata to the L1 by the user or prover. We could reduce costs of transactions by submitting batches of transactions as 4844 blobs. Note however that this would increase the time-to-finality of the IMT root update for each transaction, as we have to wait for blobs to fill up before it makes sense to post and prove them.
+Right now all keystore rollup transactions are submitted as calldata to the L1 by the user or prover. We could reduce transaction costs by submitting batches of transactions as 4844 blobs. Note however that this would increase the time-to-finality of the IMT root update for each transaction, as we have to wait for blobs to fill up before it makes sense to post and prove them.

--- a/docs/pages/syncing-l2.mdx
+++ b/docs/pages/syncing-l2.mdx
@@ -15,7 +15,7 @@ We expect L2s to sync to Keyspace's state root using Merkle proofs of the L1 Key
 Rollups typically implement a block hash oracle to verify the state root of the L1 chain. The oracle can be used to verify the state root of the L1 KeyStore contract, which can then be used to verify the state root of the L2 KeyStore contract.
 
 :::note
-Since the L1 block hash changes frequently, it can be difficult to generate a proof and submit it onchain before the L1 block hash changes. Instead, syncing via block hash proofs has been implemented as a two step process where the current block hash is read from the oracle and stored in the L2 KeyStore contract. That gives a fixed block hash to generate proofs from where the expiry time is under your control instead of the L2's rollup protocol.
+Since the L1 block hash changes frequently, it can be difficult to generate a proof and submit it onchain before the L1 block hash changes. Instead, syncing via block hash proofs has been implemented as a two-step process where the current block hash is read from the oracle and stored in the L2 KeyStore contract. That gives a fixed block hash to generate proofs from where the expiry time is under your control instead of the L2's rollup protocol.
 
 In practice, the L1 block hash on OP Stack rollups seems to take 5-6 minutes to catch up after an L1 block has been validated. This yields a total key change latency of 10-15 minutes.
 :::

--- a/docs/pages/syncing-other-l1.mdx
+++ b/docs/pages/syncing-other-l1.mdx
@@ -20,4 +20,4 @@ Keyspace's Testnet Beta includes a proof-of-concept that syncs to the testnets o
 
 ## Re-Sequencing on Other L1s
 
-We can potentially avoid the security risks of oracles by re-sequencing the state transitions on the other L1. We don't expect to pursue this path because diverging keystores are hard to reason about and are unlikely to deliver the experience we want for Keyspace users. But for scenarios where no reliable block hash oracle exists, re-sequencing may be the only option.
+We can potentially avoid the security risks of oracles by re-sequencing the state transitions on the other L1. We do not expect to pursue this path because diverging keystores are hard to reason about and are unlikely to deliver the experience we want for Keyspace users. But for scenarios where no reliable block hash oracle exists, re-sequencing may be the only option.

--- a/docs/pages/web-services.mdx
+++ b/docs/pages/web-services.mdx
@@ -10,7 +10,7 @@ For Keyspace-integrated wallets, wallet vendors can expect to run two support se
 
 ## Signing Key Indexer
 
-Anyone can run a Keyspace node to have a local copy of the Keyspace database that can be queried directly or via the `mksr_get` JSON RPC call exposed by the node. However, we expect many wallet vendors to want to update their own databases when a user changes their wallet configuration. This helps provide APIs to connect the signing key present in the application with wallets that the key is authorized to access.
+Anyone can run a Keyspace node to have a local copy of the Keyspace database that can be queried directly or via the `mksr_get` JSON-RPC call exposed by the node. However, we expect many wallet vendors to want to update their own databases when a user changes their wallet configuration. This helps provide APIs to connect the signing key present in the application with wallets that the key is authorized to access.
 
 ## Recovery Proof Service
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.
Description correction:

Corrected "doesn't" to " does not".
Corrected "go-ethereum" to "Go-Ethereum".
Corrected "JSON RPC" to "JSON-RPC".
Added "be" to "can extracted".
Corrected "can't" to "can not".
Corrected "indexes" to "index".
Corrected "exclusion / inclusion" to "exclusion/inclusion".
Corrected "therefore" to "thereby".
Corrected "approx." to "approximately".
Corrected "two step" to "two-step" and much more. 
Please review the changes and let me know if any additional changes are needed before merging.

