### PR TITLE
Resolve ECDSA Import Conflict change-owner.ts

### DIFF
--- a/scripts/change-owner.ts
+++ b/scripts/change-owner.ts
@@ -1,13 +1,12 @@
 import { ArgumentParser } from "argparse";
 
 import { defaultToEnv } from "./lib/argparse";
-import { ECDSA } from "../src/encode-signatures/secp256k1";
+import { ECDSA as Secp256k1ECDSA } from "../src/encode-signatures/secp256k1"; // Renamed import
 import { changeOwnerSecp256k1, changeOwnerWebAuthn } from "../src/keyspace";
 import { vkHashEcdsaAccount } from "./lib/secp256k1";
 import { keyspaceClient, recoveryClient } from "./lib/client";
 import { authenticatorData } from "./lib/webauthn";
-const ECDSA = require("ecdsa-secp256r1");
-
+const Secp256r1ECDSA = require("ecdsa-secp256r1"); // Renamed import
 
 function main() {
   const parser = new ArgumentParser({
@@ -42,8 +41,8 @@ function main() {
       recoveryClient,
     });
   } else if (args.signature_type === "webauthn") {
-    const currentPrivateKey = ECDSA.fromJWK(JSON.parse(args.private_key));
-    const newPrivateKey = ECDSA.fromJWK(JSON.parse(args.new_private_key));
+    const currentPrivateKey = Secp256r1ECDSA.fromJWK(JSON.parse(args.private_key)); // Updated
+    const newPrivateKey = Secp256r1ECDSA.fromJWK(JSON.parse(args.new_private_key)); // Updated
     changeOwnerWebAuthn({
       keyspaceKey: args.keyspace_key,
       currentPrivateKey,


### PR DESCRIPTION
### Problem:
In your script, the `ECDSA` identifier is imported from two different sources:

1. **From `../src/encode-signatures/secp256k1`**:
   ```typescript
   import { ECDSA } from "../src/encode-signatures/secp256k1";
   ```

2. **Using `require("ecdsa-secp256r1")`**:
   ```typescript
   const ECDSA = require("ecdsa-secp256r1");
   ```

This creates a naming conflict, as the second declaration of `ECDSA` overrides the first. This could lead to runtime errors or unintended behavior when referencing `ECDSA` in the code.

---

### Solution:
To resolve the conflict, I renamed the imports to clearly distinguish between the two `ECDSA` implementations:

```typescript
import { ECDSA as Secp256k1ECDSA } from "../src/encode-signatures/secp256k1";
const Secp256r1ECDSA = require("ecdsa-secp256r1");
```

Subsequently, all references to `ECDSA` in the code have been updated to use the appropriate renamed import. For example:

```typescript
const currentPrivateKey = Secp256r1ECDSA.fromJWK(JSON.parse(args.private_key));
const newPrivateKey = Secp256r1ECDSA.fromJWK(JSON.parse(args.new_private_key));
```

---

### Importance:
This fix ensures the following:
1. Prevents runtime errors caused by identifier collisions.
2. Guarantees that the correct `ECDSA` implementation is used in the relevant sections of the code.
3. Improves code readability and maintainability by making the source of each `ECDSA` implementation explicit.

This change eliminates ambiguity and ensures the script operates as intended.