### PR TITLE
Fix terminology mismatch Update send-eth.ts

### DIFF
--- a/scripts/send-eth.ts
+++ b/scripts/send-eth.ts
@@ -37,7 +37,7 @@ async function main() {
     baseModule = keyspaceWebAuthnBase;
     privateKey = ECDSA.fromJWK(JSON.parse(args.private_key));
   } else {
-    console.error("Invalid circuit type");
+    console.error("Invalid signature type");
   }
 
   const to = await getAccount(client, args.keyspace_key, 0n, args.signature_type);


### PR DESCRIPTION
### Problem:  
In the provided script, the error message in the `else` block reads:  
```ts
console.error("Invalid circuit type");
```  
This is inconsistent with the rest of the script, where the term **"signature type"** is used. The mismatch can lead to confusion during debugging, as it does not align with the `--signature-type` argument or its intended meaning in the script.

---

### Solution:  
Update the error message to correctly refer to "signature type":  
```ts
console.error("Invalid signature type");
```

---

### Importance:  
1. **Improves Clarity**: Ensures the error message accurately describes the issue and aligns with the rest of the script.  
2. **Reduces Debugging Complexity**: Avoids potential confusion caused by a mismatch in terminology.  
3. **Maintains Consistency**: Reinforces the usage of the term "signature type," which is integral to the script's functionality.  

---

### Changes Made:  
Replaced:  
```ts
console.error("Invalid circuit type");
```  
With:  
```ts
console.error("Invalid signature type");
```  

This ensures the error message reflects the correct context and matches the argument used in the script.