### PR TITLE
docs: Fix typos

### DIFF
--- a/docs/pages/updating-keystore.mdx
+++ b/docs/pages/updating-keystore.mdx
@@ -75,7 +75,7 @@ Once we have the state root for the master chain, we just need to prove storage 
 Syncing via deposits and withdrawals has not been implemented as of v0.1.0.
 :::
 
-Deposits and withdrawals are the canonical method for sending messages between chains. That makes them extemely resilient: the whole ecosystem builds on top of withdrawals and deposits with the expectaction that they will succeed for the lifetime of the chains. Rollup teams ensure that their bridge contracts continue to function through each hard fork.
+Deposits and withdrawals are the canonical method for sending messages between chains. That makes them extremely resilient: the whole ecosystem builds on top of withdrawals and deposits with the expectation that they will succeed for the lifetime of the chains. Rollup teams ensure that their bridge contracts continue to function through each hard fork.
 
 The downsides of deposits and withdrawals are that they require a transaction to be sent on a separate chain from the one the user is interacting with, and that these transactions have significant costs on L1.
 

--- a/docs/pages/using-new-signers.mdx
+++ b/docs/pages/using-new-signers.mdx
@@ -7,7 +7,7 @@ description: Learn how to add and manage new signers in your Keyspace wallet
 
 When a new signer is configured, it's written directly to the master chain. But what if the new signer wants to start sending transactions on another chain? If that chain hasn't been synced recently, a sync will be necessary. And if the new signer was just added, that master chain block won't settle on L1 for 3.5 days (and up to 10 days in the case of optimistic rollup disputes).
 
-To get make new signers usable immediately, Keyspace supports *preconfirmations*, which replay the `setConfig` call from the master chain on a replica chain with the same arguments. The difference between `setConfig` on the master chain and `setConfig` on a replica chain is that if the replica chain's configuration conflicts with the master chain's configuration, the replica chain's configuration will eventually be overwritten during a sync.
+To make new signers usable immediately, Keyspace supports *preconfirmations*, which replay the `setConfig` call from the master chain on a replica chain with the same arguments. The difference between `setConfig` on the master chain and `setConfig` on a replica chain is that if the replica chain's configuration conflicts with the master chain's configuration, the replica chain's configuration will eventually be overwritten during a sync.
 
 ## Sync and Preconfirm with the New Signer
 


### PR DESCRIPTION
A couple of typos and a redundant word in the documentation files: 

1. In `updating-keystore.mdx`, corrected "extemely" to "extremely" and "expectaction" to "expectation".  
2. In `using-new-signers.mdx`, removed the unnecessary word "get".  

Based.