### PR TITLE
Fix Typo in Updating Keystore Documentation

### DIFF
--- a/docs/pages/updating-keystore.mdx
+++ b/docs/pages/updating-keystore.mdx
@@ -71,7 +71,7 @@ Once we have the state root for the master chain, we just need to prove storage 
 
 ### Syncing via Deposits and Withdrawals
 
-Deposits and withdrawals are the canonical method for sending messages between chains. That makes them extemely resilient: the whole ecosystem builds on top of withdrawals and deposits with the expectaction that they will succeed for the lifetime of the chains. Rollup teams ensure that their bridge contracts continue to function through each hard fork.
+Deposits and withdrawals are the canonical method for sending messages between chains. That makes them extremely resilient: the whole ecosystem builds on top of withdrawals and deposits with the expectaction that they will succeed for the lifetime of the chains. Rollup teams ensure that their bridge contracts continue to function through each hard fork.
 
 The downsides of deposits and withdrawals are that they require a transaction to be sent on a separate chain from the one the user is interacting with, and that these transactions have significant costs on L1.
 


### PR DESCRIPTION


**Description:** 
This pull request corrects a typo in the `updating-keystore.mdx` file. The word "extemely" has been corrected to "extremely" in the section discussing the resilience of deposits and withdrawals as a method for sending messages between chains. This change ensures clarity and accuracy in the documentation.
